### PR TITLE
Mark imports as implicit

### DIFF
--- a/source/ghc-9.4/Imp/Ghc.hs
+++ b/source/ghc-9.4/Imp/Ghc.hs
@@ -13,7 +13,7 @@ newImportDecl moduleName =
   Hs.ImportDecl
     { Hs.ideclExt = Hs.noAnn,
       Hs.ideclSourceSrc = SourceText.NoSourceText,
-      Hs.ideclImplicit = False,
+      Hs.ideclImplicit = True,
       Hs.ideclName = Hs.noLocA moduleName,
       Hs.ideclPkgQual = Plugin.NoRawPkgQual,
       Hs.ideclSource = Plugin.NotBoot,

--- a/source/ghc-9.6/Imp/Ghc.hs
+++ b/source/ghc-9.6/Imp/Ghc.hs
@@ -15,7 +15,7 @@ newImportDecl moduleName =
         Hs.XImportDeclPass
           { Hs.ideclAnn = Hs.noAnn,
             Hs.ideclSourceText = SourceText.NoSourceText,
-            Hs.ideclImplicit = False
+            Hs.ideclImplicit = True
           },
       Hs.ideclName = Hs.noLocA moduleName,
       Hs.ideclPkgQual = Plugin.NoRawPkgQual,

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -32,31 +32,31 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "Imp" $ do
     expectImp
       []
       "true = Data.Bool.True"
-      "import qualified Data.Bool\ntrue = Data.Bool.True"
+      "import (implicit) qualified Data.Bool\ntrue = Data.Bool.True"
 
   Hspec.it "inserts an aliased import" $ do
     expectImp
       ["--alias=Data.Bool:Bool"]
       "true = Bool.True"
-      "import qualified Data.Bool as Bool\ntrue = Bool.True"
+      "import (implicit) qualified Data.Bool as Bool\ntrue = Bool.True"
 
   Hspec.it "prefers later aliases over earlier ones" $ do
     expectImp
       ["--alias=Relude.Bool:Bool", "--alias=Data.Bool:Bool"]
       "true = Bool.True"
-      "import qualified Data.Bool as Bool\ntrue = Bool.True"
+      "import (implicit) qualified Data.Bool as Bool\ntrue = Bool.True"
 
   Hspec.it "inserts an import for a qualified type" $ do
     expectImp
       []
       "true = True :: Data.Bool.Bool"
-      "import qualified Data.Bool\ntrue = True :: Data.Bool.Bool"
+      "import (implicit) qualified Data.Bool\ntrue = True :: Data.Bool.Bool"
 
   Hspec.it "inserts multiple imports sorted" $ do
     expectImp
       []
       "true :: Relude.Bool.Bool\ntrue = Data.Bool.True"
-      "import qualified Data.Bool\nimport qualified Relude.Bool\ntrue :: Relude.Bool.Bool\ntrue = Data.Bool.True"
+      "import (implicit) qualified Data.Bool\nimport (implicit) qualified Relude.Bool\ntrue :: Relude.Bool.Bool\ntrue = Data.Bool.True"
 
   Hspec.it "does not re-import an open import" $ do
     expectImp
@@ -80,7 +80,7 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "Imp" $ do
     expectImp
       []
       "import qualified Relude.Bool\ntrue :: Relude.Bool.Bool\ntrue = Data.Bool.True"
-      "import qualified Relude.Bool\nimport qualified Data.Bool\ntrue :: Relude.Bool.Bool\ntrue = Data.Bool.True"
+      "import qualified Relude.Bool\nimport (implicit) qualified Data.Bool\ntrue :: Relude.Bool.Bool\ntrue = Data.Bool.True"
 
 expectImp :: (Stack.HasCallStack) => [String] -> String -> String -> Hspec.Expectation
 expectImp arguments input expected = do


### PR DESCRIPTION
Consider a simple module like this:

``` hs
{-# OPTIONS_GHC -Wunused-imports -fplugin=Imp #-}
main = System.IO.print ()
```

Before the changes in this PR, compiling that module would generate a warning like this:

```
<no location info>: warning: [GHC-66111] [-Wunused-imports]
    The qualified import of ‘System.IO’ is redundant
      except perhaps to import instances from ‘System.IO’
    To import instances alone, use: import System.IO()
```

That's not ideal since (a) the import is actually used and (b) the user didn't import the module themselves anyway, so they have no way to fix the warning. By changing it to an implicit import, the warning can be avoided. 

Ideally there would be some other way to avoid this warning, but I don't know of any alternative. 