### PR TITLE
Avoid importing by generating exact names directly

### DIFF
--- a/imp.cabal
+++ b/imp.cabal
@@ -64,6 +64,7 @@ library
     Imp.Extra.HsModule
     Imp.Extra.HsParsedModule
     Imp.Extra.ImportDecl
+    Imp.Extra.Located
     Imp.Extra.ModuleName
     Imp.Extra.ParsedResult
     Imp.Extra.ReadP

--- a/source/library/Imp.hs
+++ b/source/library/Imp.hs
@@ -1,19 +1,25 @@
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Imp where
 
+import qualified Control.Monad as Monad
 import qualified Control.Monad.Catch as Exception
+import qualified Control.Monad.IO.Class as MonadIO
 import qualified Data.Data as Data
 import qualified Data.Map as Map
 import qualified Data.Set as Set
+import qualified GHC.Driver.Main as Driver
 import qualified GHC.Hs as Hs
 import qualified GHC.Plugins as Plugin
+import qualified GHC.Types.Name.Cache as NameCache
 import qualified Imp.Exception.ShowHelp as ShowHelp
 import qualified Imp.Exception.ShowVersion as ShowVersion
 import qualified Imp.Extra.Exception as Exception
 import qualified Imp.Extra.HsModule as HsModule
 import qualified Imp.Extra.HsParsedModule as HsParsedModule
 import qualified Imp.Extra.ImportDecl as ImportDecl
+import qualified Imp.Extra.Located as Located
 import qualified Imp.Extra.ParsedResult as ParsedResult
 import qualified Imp.Ghc as Ghc
 import qualified Imp.Type.Config as Config
@@ -34,10 +40,13 @@ parsedResultAction ::
   modSummary ->
   Plugin.ParsedResult ->
   Plugin.Hsc Plugin.ParsedResult
-parsedResultAction commandLineOptions _ =
+parsedResultAction commandLineOptions _ parsedResult = do
+  hscEnv <- Driver.getHscEnv
   Plugin.liftIO
     . Exception.handle handleException
-    . ParsedResult.overModule (HsParsedModule.overModule $ imp commandLineOptions)
+    $ ParsedResult.overModule
+      (HsParsedModule.overModule $ imp commandLineOptions (Plugin.hsc_units hscEnv) (Plugin.hsc_NC hscEnv))
+      parsedResult
 
 handleException :: Exception.SomeException -> IO a
 handleException e = do
@@ -51,24 +60,49 @@ exceptionToExitCode e
   | otherwise = Exit.ExitFailure 1
 
 imp ::
-  (Exception.MonadThrow m) =>
+  (MonadIO.MonadIO m, Exception.MonadThrow m) =>
   [String] ->
+  Plugin.UnitState ->
+  NameCache.NameCache ->
   Plugin.Located Ghc.HsModulePs ->
   m (Plugin.Located Ghc.HsModulePs)
-imp arguments lHsModule = do
+imp arguments unitState nameCache lHsModule = do
   flags <- Flag.fromArguments arguments
   config <- Config.fromFlags flags
   context <- Context.fromConfig config
   let aliases = Context.aliases context
-      moduleNames =
-        Set.fromList @Plugin.ModuleName
-          . biplate
-          . Hs.hsmodDecls
-          $ Plugin.unLoc lHsModule
-  pure $ fmap (HsModule.overImports $ updateImports aliases moduleNames) lHsModule
 
-biplate :: (Data.Data a, Data.Data b) => a -> [b]
-biplate = concat . Data.gmapQ (\d -> maybe (biplate d) pure $ Data.cast d)
+  Located.overValue
+    ( HsModule.overDecls $
+        overData
+          ( \x -> case Data.cast x of
+              Nothing -> pure x
+              Just old -> do
+                new <- case old of
+                  Plugin.Qual moduleName occName -> do
+                    let target = Map.findWithDefault moduleName moduleName aliases
+                    case Plugin.lookupModuleWithSuggestions unitState target Plugin.NoPkgQual of
+                      Plugin.LookupFound module_ _ ->
+                        fmap Plugin.Exact
+                          . MonadIO.liftIO
+                          . NameCache.updateNameCache nameCache module_ occName
+                          $ \oldNameCache ->
+                            case NameCache.lookupOrigNameCache oldNameCache module_ occName of
+                              Just name -> pure (oldNameCache, name)
+                              Nothing -> do
+                                unique <- NameCache.takeUniqFromNameCache nameCache
+                                let name = Plugin.mkExternalName unique module_ occName Plugin.generatedSrcSpan
+                                    newNameCache = NameCache.extendOrigNameCache oldNameCache module_ occName name
+                                pure (newNameCache, name)
+                      _ -> pure old
+                  _ -> pure old
+                maybe (error "couldn't cast RdrName back into Data") pure $ Data.cast new
+          )
+    )
+    lHsModule
+
+overData :: (Data.Data a, Monad m) => (forall b. (Data.Data b) => b -> m b) -> a -> m a
+overData g = Data.gmapM $ overData g Monad.>=> g
 
 updateImports ::
   Map.Map Plugin.ModuleName Plugin.ModuleName ->

--- a/source/library/Imp/Extra/HsModule.hs
+++ b/source/library/Imp/Extra/HsModule.hs
@@ -3,6 +3,13 @@ module Imp.Extra.HsModule where
 import qualified GHC.Hs as Hs
 import qualified Imp.Ghc as Ghc
 
+overDecls ::
+  (Functor f) =>
+  ([Hs.LHsDecl Hs.GhcPs] -> f [Hs.LHsDecl Hs.GhcPs]) ->
+  Ghc.HsModulePs ->
+  f Ghc.HsModulePs
+overDecls f x = (\y -> x {Hs.hsmodDecls = y}) <$> f (Hs.hsmodDecls x)
+
 overImports ::
   ([Hs.LImportDecl Hs.GhcPs] -> [Hs.LImportDecl Hs.GhcPs]) ->
   Ghc.HsModulePs ->

--- a/source/library/Imp/Extra/Located.hs
+++ b/source/library/Imp/Extra/Located.hs
@@ -1,0 +1,6 @@
+module Imp.Extra.Located where
+
+import qualified GHC.Plugins as Plugin
+
+overValue :: (Functor f) => (a -> f b) -> Plugin.Located a -> f (Plugin.Located b)
+overValue f (Plugin.L l e) = Plugin.L l <$> f e


### PR DESCRIPTION
Fixes #12. 

All the types line up, but unfortunately this doesn't work as written. Given a simple module like this:

``` hs
{-# OPTIONS_GHC -fplugin=Imp #-}

main :: System.IO.IO ()
main = System.IO.print ()
```

It fails to compile:

```
Main.hs:3:9: error: [GHC-83249]
    Can't find interface-file declaration for type constructor or class System.IO.IO
      Probable cause: bug in .hi-boot file, or inconsistent .hi file
      Use -ddump-if-trace to get an idea of which file caused the error
  |
3 | main :: System.IO.IO ()
  |         ^^^^^^^^^^^^
```

Curiously it works fine without the type signature. 