### PR TITLE
Locate imports at their first use site

### DIFF
--- a/imp.cabal
+++ b/imp.cabal
@@ -67,6 +67,7 @@ library
     Imp.Extra.ModuleName
     Imp.Extra.ParsedResult
     Imp.Extra.ReadP
+    Imp.Extra.SrcSpanAnnN
     Imp.Ghc
     Imp.Type.Alias
     Imp.Type.Config

--- a/source/library/Imp/Extra/SrcSpanAnnN.hs
+++ b/source/library/Imp/Extra/SrcSpanAnnN.hs
@@ -1,0 +1,11 @@
+module Imp.Extra.SrcSpanAnnN where
+
+import qualified Data.Function as Function
+import qualified GHC.Hs as Hs
+import qualified GHC.Plugins as Plugin
+
+leftmostSmallest :: Hs.SrcSpanAnnN -> Hs.SrcSpanAnnN -> Hs.SrcSpanAnnN
+leftmostSmallest x y = case Function.on Plugin.leftmost_smallest Hs.locA x y of
+  LT -> x
+  EQ -> x
+  GT -> y


### PR DESCRIPTION
This was motivated by #12 but ultimately unrelated to that.

This PR updates the generated imports to actually have a location. Previously imports would have no location. This is generally fine, but it meant that if you tried to import a module that didn't exist, you'd get an error at the top of the file like this:

``` hs
{-# OPTIONS_GHC -fplugin=Imp #-}

main = DoesNotExist.print ()
```

```
Main.hs:1:1: error: [GHC-87110]
    Could not find module ‘DoesNotExist’.
    Use -v to see a list of the files searched for.
  |
1 | {-# OPTIONS_GHC -fplugin=Imp #-}
  | ^
```

That's not _wrong_ since the import doesn't actually exist in the source file, but it's not very helpful either. After the changes in this PR, the imports are "located" at the same place as their first use site. That means that if you try to import a module that doesn't exist, you'll get an error at that use site:

```
Main.hs:3:8: error: [GHC-87110]
    Could not find module ‘DoesNotExist’.
    Use -v to see a list of the files searched for.
  |
3 | main = DoesNotExist.print ()
  |        ^^^^^^^^^^^^^^^^^^
```

This is much nicer and should make it easier to debug when things go wrong. Note that this also applies to modules that are hidden:

```
Main.hs:3:8: error: [GHC-87110]
    Could not load module ‘Data.Text.IO’.
    It is a member of the hidden package ‘text-2.1.1’.
    Perhaps you need to add ‘text’ to the build-depends in your .cabal file.
    Use -v to see a list of the files searched for.
  |
3 | main = Data.Text.IO.putStrLn ""
  |        ^^^^^^^^^^^^^^^^^^^^^
```

Unfortunately I couldn't think of a way to (easily) test this since the locations aren't included in the output. 