### PR TITLE
Allow aliasing current module

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -69,7 +69,7 @@
           }
         },
         {
-          "run": "cabal test"
+          "run": "cabal run -- imp-test-suite --randomize --strict"
         }
       ],
       "strategy": {

--- a/README.md
+++ b/README.md
@@ -75,6 +75,30 @@ main = IO.print ()
 
 Later aliases will override earlier ones.
 
+## Aliasing Current Module
+
+You can use the special source module name `_` (a single underscore) to refer
+to the current module. This allows you to disambiguate identifiers without
+referring to the current module name. For example if you want to use `This`,
+you can do so with `--alias=_:This`. As a complete example, this input:
+
+``` hs
+{-# OPTIONS_GHC
+  -fplugin=Imp
+  -fplugin-opt=Imp:--alias=_:This #-}
+module Qualified.Example where
+print = putStrLn . show
+defaultMain = This.print ()
+```
+
+Will effectively produce this output:
+
+``` hs
+module Qualified.Example where
+print = putStrLn . show
+defaultMain = Qualified.Example.print ()
+```
+
 ## Recommended Usage
 
 Combining the previous sections, the recommended usage of Imp is to enable it
@@ -86,6 +110,7 @@ library
   build-depends: imp ^>= 1.0.0.0
   ghc-options:
     -fplugin=Imp
+    -fplugin-opt=Imp:--alias=_:This
     -fplugin-opt=Imp:--alias=Data.Map.Strict:Map
     -fplugin-opt=Imp:--alias=Data.Sequence:Seq
     -fplugin-opt=Imp:--alias=Data.Set:Set

--- a/imp.cabal
+++ b/imp.cabal
@@ -73,6 +73,7 @@ library
     Imp.Type.Config
     Imp.Type.Context
     Imp.Type.Flag
+    Imp.Type.Source
     Imp.Type.Target
 
   hs-source-dirs: source/library

--- a/imp.cabal
+++ b/imp.cabal
@@ -73,6 +73,7 @@ library
     Imp.Type.Config
     Imp.Type.Context
     Imp.Type.Flag
+    Imp.Type.Target
 
   hs-source-dirs: source/library
   other-modules: Paths_imp

--- a/imp.cabal
+++ b/imp.cabal
@@ -49,6 +49,7 @@ library
     containers ^>=0.6.7,
     exceptions ^>=0.10.5,
     ghc ^>=9.4.1 || ^>=9.6.1 || ^>=9.8.1,
+    transformers ^>=0.5.6 || ^>=0.6.1,
 
   -- cabal-gild: discover source/ghc-9.4 source/ghc-9.6 source/library
   exposed-modules:
@@ -64,6 +65,7 @@ library
     Imp.Extra.HsModule
     Imp.Extra.HsParsedModule
     Imp.Extra.ImportDecl
+    Imp.Extra.Located
     Imp.Extra.ModuleName
     Imp.Extra.ParsedResult
     Imp.Extra.ReadP

--- a/source/library/Imp.hs
+++ b/source/library/Imp.hs
@@ -21,6 +21,7 @@ import qualified Imp.Ghc as Ghc
 import qualified Imp.Type.Config as Config
 import qualified Imp.Type.Context as Context
 import qualified Imp.Type.Flag as Flag
+import qualified Imp.Type.Target as Target
 import qualified System.Exit as Exit
 import qualified System.IO as IO
 
@@ -78,7 +79,7 @@ biplate :: (Data.Data a, Data.Data b) => a -> [b]
 biplate = concat . Data.gmapQ (\d -> maybe (biplate d) pure $ Data.cast d)
 
 updateImports ::
-  Map.Map Plugin.ModuleName Plugin.ModuleName ->
+  Map.Map Target.Target Plugin.ModuleName ->
   Map.Map Plugin.ModuleName Hs.SrcSpanAnnN ->
   [Hs.LImportDecl Hs.GhcPs] ->
   [Hs.LImportDecl Hs.GhcPs]
@@ -88,11 +89,11 @@ updateImports aliases want imports =
    in imports <> fmap (\(m, l) -> Plugin.L (Hs.na2la l) $ createImport aliases m) need
 
 createImport ::
-  Map.Map Plugin.ModuleName Plugin.ModuleName ->
+  Map.Map Target.Target Plugin.ModuleName ->
   Plugin.ModuleName ->
   Hs.ImportDecl Hs.GhcPs
 createImport aliases target =
-  let source = Map.findWithDefault target target aliases
+  let source = Map.findWithDefault target (Target.fromModuleName target) aliases
    in (Ghc.newImportDecl source)
         { Hs.ideclAs =
             if source == target

--- a/source/library/Imp/Extra/HsModule.hs
+++ b/source/library/Imp/Extra/HsModule.hs
@@ -3,6 +3,13 @@ module Imp.Extra.HsModule where
 import qualified GHC.Hs as Hs
 import qualified Imp.Ghc as Ghc
 
+overDecls ::
+  (Functor f) =>
+  ([Hs.LHsDecl Hs.GhcPs] -> f [Hs.LHsDecl Hs.GhcPs]) ->
+  Ghc.HsModulePs ->
+  f Ghc.HsModulePs
+overDecls f x = (\y -> x {Hs.hsmodDecls = y}) <$> f (Hs.hsmodDecls x)
+
 overImports ::
   ([Hs.LImportDecl Hs.GhcPs] -> [Hs.LImportDecl Hs.GhcPs]) ->
   Ghc.HsModulePs ->

--- a/source/library/Imp/Extra/Located.hs
+++ b/source/library/Imp/Extra/Located.hs
@@ -1,0 +1,6 @@
+module Imp.Extra.Located where
+
+import qualified GHC.Plugins as Plugin
+
+overValue :: (Functor f) => (a -> f b) -> Plugin.Located a -> f (Plugin.Located b)
+overValue f (Plugin.L l e) = Plugin.L l <$> f e

--- a/source/library/Imp/Type/Alias.hs
+++ b/source/library/Imp/Type/Alias.hs
@@ -6,10 +6,11 @@ import qualified Data.Map as Map
 import qualified GHC.Plugins as Plugin
 import qualified Imp.Exception.InvalidAlias as InvalidAlias
 import qualified Imp.Extra.ModuleName as ModuleName
+import qualified Imp.Type.Target as Target
 
 data Alias = Alias
   { source :: Plugin.ModuleName,
-    target :: Plugin.ModuleName
+    target :: Target.Target
   }
   deriving (Eq, Show)
 
@@ -18,8 +19,8 @@ fromString string = do
   let (before, after) = break (== ':') string
   Monad.when (null after) . Exception.throwM $ InvalidAlias.new string
   src <- ModuleName.fromString before
-  tgt <- ModuleName.fromString . drop 1 $ after
+  tgt <- Target.fromString . drop 1 $ after
   pure Alias {source = src, target = tgt}
 
-toMap :: [Alias] -> Map.Map Plugin.ModuleName Plugin.ModuleName
+toMap :: [Alias] -> Map.Map Target.Target Plugin.ModuleName
 toMap = Map.fromListWith (const id) . fmap (\x -> (target x, source x))

--- a/source/library/Imp/Type/Alias.hs
+++ b/source/library/Imp/Type/Alias.hs
@@ -3,13 +3,12 @@ module Imp.Type.Alias where
 import qualified Control.Monad as Monad
 import qualified Control.Monad.Catch as Exception
 import qualified Data.Map as Map
-import qualified GHC.Plugins as Plugin
 import qualified Imp.Exception.InvalidAlias as InvalidAlias
-import qualified Imp.Extra.ModuleName as ModuleName
+import qualified Imp.Type.Source as Source
 import qualified Imp.Type.Target as Target
 
 data Alias = Alias
-  { source :: Plugin.ModuleName,
+  { source :: Source.Source,
     target :: Target.Target
   }
   deriving (Eq, Show)
@@ -18,9 +17,9 @@ fromString :: (Exception.MonadThrow m) => String -> m Alias
 fromString string = do
   let (before, after) = break (== ':') string
   Monad.when (null after) . Exception.throwM $ InvalidAlias.new string
-  src <- ModuleName.fromString before
+  src <- Source.fromString before
   tgt <- Target.fromString . drop 1 $ after
   pure Alias {source = src, target = tgt}
 
-toMap :: [Alias] -> Map.Map Target.Target Plugin.ModuleName
+toMap :: [Alias] -> Map.Map Target.Target Source.Source
 toMap = Map.fromListWith (const id) . fmap (\x -> (target x, source x))

--- a/source/library/Imp/Type/Context.hs
+++ b/source/library/Imp/Type/Context.hs
@@ -3,15 +3,15 @@ module Imp.Type.Context where
 import qualified Control.Monad as Monad
 import qualified Control.Monad.Catch as Exception
 import qualified Data.Map as Map
-import qualified GHC.Plugins as Plugin
 import qualified Imp.Exception.ShowHelp as ShowHelp
 import qualified Imp.Exception.ShowVersion as ShowVersion
 import qualified Imp.Type.Alias as Alias
 import qualified Imp.Type.Config as Config
+import qualified Imp.Type.Source as Source
 import qualified Imp.Type.Target as Target
 
 newtype Context = Context
-  { aliases :: Map.Map Target.Target Plugin.ModuleName
+  { aliases :: Map.Map Target.Target Source.Source
   }
   deriving (Eq, Show)
 

--- a/source/library/Imp/Type/Context.hs
+++ b/source/library/Imp/Type/Context.hs
@@ -8,9 +8,10 @@ import qualified Imp.Exception.ShowHelp as ShowHelp
 import qualified Imp.Exception.ShowVersion as ShowVersion
 import qualified Imp.Type.Alias as Alias
 import qualified Imp.Type.Config as Config
+import qualified Imp.Type.Target as Target
 
 newtype Context = Context
-  { aliases :: Map.Map Plugin.ModuleName Plugin.ModuleName
+  { aliases :: Map.Map Target.Target Plugin.ModuleName
   }
   deriving (Eq, Show)
 

--- a/source/library/Imp/Type/Source.hs
+++ b/source/library/Imp/Type/Source.hs
@@ -17,3 +17,8 @@ fromString s =
   if s == "_"
     then pure Implicit
     else fromModuleName <$> ModuleName.fromString s
+
+isImplicit :: Source -> Bool
+isImplicit s = case s of
+  Implicit -> True
+  Explicit _ -> False

--- a/source/library/Imp/Type/Source.hs
+++ b/source/library/Imp/Type/Source.hs
@@ -4,15 +4,16 @@ import qualified Control.Monad.Catch as Exception
 import qualified GHC.Plugins as Plugin
 import qualified Imp.Extra.ModuleName as ModuleName
 
-newtype Source
-  = Source Plugin.ModuleName
+data Source
+  = Implicit
+  | Explicit Plugin.ModuleName
   deriving (Eq, Show)
 
 fromModuleName :: Plugin.ModuleName -> Source
-fromModuleName = Source
+fromModuleName = Explicit
 
 fromString :: (Exception.MonadThrow m) => String -> m Source
-fromString = fmap fromModuleName . ModuleName.fromString
-
-toModuleName :: Source -> Plugin.ModuleName
-toModuleName (Source x) = x
+fromString s =
+  if s == "_"
+    then pure Implicit
+    else fromModuleName <$> ModuleName.fromString s

--- a/source/library/Imp/Type/Source.hs
+++ b/source/library/Imp/Type/Source.hs
@@ -1,0 +1,18 @@
+module Imp.Type.Source where
+
+import qualified Control.Monad.Catch as Exception
+import qualified GHC.Plugins as Plugin
+import qualified Imp.Extra.ModuleName as ModuleName
+
+newtype Source
+  = Source Plugin.ModuleName
+  deriving (Eq, Show)
+
+fromModuleName :: Plugin.ModuleName -> Source
+fromModuleName = Source
+
+fromString :: (Exception.MonadThrow m) => String -> m Source
+fromString = fmap fromModuleName . ModuleName.fromString
+
+toModuleName :: Source -> Plugin.ModuleName
+toModuleName (Source x) = x

--- a/source/library/Imp/Type/Target.hs
+++ b/source/library/Imp/Type/Target.hs
@@ -1,0 +1,18 @@
+module Imp.Type.Target where
+
+import qualified Control.Monad.Catch as Exception
+import qualified GHC.Plugins as Plugin
+import qualified Imp.Extra.ModuleName as ModuleName
+
+newtype Target
+  = Target Plugin.ModuleName
+  deriving (Eq, Ord, Show)
+
+fromModuleName :: Plugin.ModuleName -> Target
+fromModuleName = Target
+
+fromString :: (Exception.MonadThrow m) => String -> m Target
+fromString = fmap fromModuleName . ModuleName.fromString
+
+toModuleName :: Target -> Plugin.ModuleName
+toModuleName (Target x) = x

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -95,6 +95,12 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "Imp" $ do
       "import Data.Bool\ntrue = Data.Bool.True"
       "import Data.Bool\ntrue = Data.Bool.True"
 
+  Hspec.it "does not insert an import for the current module" $ do
+    expectImp
+      []
+      "undefined = Example.undefined"
+      "undefined = Example.undefined"
+
 expectImp :: (Stack.HasCallStack) => [String] -> String -> String -> Hspec.Expectation
 expectImp arguments input expected = do
   before <- parseModule input

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -2,17 +2,14 @@
 
 import qualified Control.Monad.Catch as Exception
 import qualified GHC.Data.EnumSet as EnumSet
-import qualified GHC.Data.FastString as FastString
 import qualified GHC.Data.StringBuffer as StringBuffer
 import qualified GHC.Parser as Parser
 import qualified GHC.Parser.Lexer as Lexer
+import qualified GHC.Plugins as Plugin
 import qualified GHC.Stack as Stack
-import qualified GHC.Types.SrcLoc as SrcLoc
 import qualified GHC.Utils.Error as Error
-import qualified GHC.Utils.Outputable as Outputable
 import qualified Imp
 import qualified Imp.Ghc as Ghc
-import qualified Language.Haskell.Syntax.Module.Name as ModuleName
 import qualified Test.Hspec as Hspec
 
 main :: IO ()
@@ -104,15 +101,15 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "Imp" $ do
 expectImp :: (Stack.HasCallStack) => [String] -> String -> String -> Hspec.Expectation
 expectImp arguments input expected = do
   before <- parseModule input
-  after <- Imp.imp arguments (ModuleName.mkModuleName "Example") before
-  let actual = Outputable.showPprUnsafe after
+  after <- Imp.imp arguments (Plugin.mkModuleName "Example") before
+  let actual = Plugin.showPprUnsafe after
   actual `Hspec.shouldBe` expected
 
-parseModule :: (Exception.MonadThrow m) => String -> m (SrcLoc.Located Ghc.HsModulePs)
+parseModule :: (Exception.MonadThrow m) => String -> m (Plugin.Located Ghc.HsModulePs)
 parseModule input = do
   let parserOpts = Lexer.mkParserOpts EnumSet.empty emptyDiagOpts [] False False False False
       stringBuffer = StringBuffer.stringToStringBuffer input
-      realSrcLoc = SrcLoc.mkRealSrcLoc (FastString.mkFastString "<interactive>") 1 1
+      realSrcLoc = Plugin.mkRealSrcLoc (Plugin.mkFastString "<interactive>") 1 1
       pState = Lexer.initParserState parserOpts stringBuffer realSrcLoc
       parseResult = Lexer.unP Parser.parseModule pState
   case parseResult of
@@ -123,7 +120,7 @@ emptyDiagOpts :: Error.DiagOpts
 #if MIN_VERSION_ghc(9, 8, 1)
 emptyDiagOpts = Error.emptyDiagOpts
 #else
-emptyDiagOpts = Error.DiagOpts EnumSet.empty EnumSet.empty False False Nothing Outputable.defaultSDocContext
+emptyDiagOpts = Error.DiagOpts EnumSet.empty EnumSet.empty False False Nothing Plugin.defaultSDocContext
 #endif
 
 newtype InvalidInput


### PR DESCRIPTION
Fixes #13. 

This PR introduces a special alias source named `_` that can be used as a stand-in for the current module. For example, this input:

``` hs
{-# OPTIONS_GHC
  -fplugin=Imp
  -fplugin-opt=Imp:--alias=_:Self #-}
module Qualified.Example where
print = putStrLn . show
defaultMain = Self.print
```

Will produce this output:

``` hs
module Qualified.Example where
print = putStrLn . show
defaultMain = Qualified.Example.print
```

Note that the name `_` is special, but the name `Self` is not. You can use whatever you want, like `This` or `Current`. You can even set up multiple aliases for the current module if you want that for some reason. 

---

This PR also fixes a bug where imports for the current module were incorrectly being added. Previously this input:

``` hs
module Example where
undefined = Example.undefined
```

Would produce this output:

``` hs
module Example where
import qualified Example
undefined = Example.undefined
```

Which is always an error since a module cannot import itself. Now no import statement will be generated in this scenario. 