### PR TITLE
Allow specifying packages for ambiguous modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,29 @@ library
     -- and so on ...
 ```
 
+## Package Imports
+
+It's possible that the same module name can be defined in two different
+packages. In normal Haskell code, you can disambiguate using the
+`PackageImports` language extension. To do the same with Imp, use the
+`--package=MODULE:PACKAGE` option. For example, consider the following module:
+
+``` hs
+{-# LANGUAGE PackageImports #-}
+{-# OPTIONS_GHC
+  -fplugin=Imp
+  -fplugin-opt=Imp:--package=Data.SemVer:semver #-}
+main = print Data.SemVer.initial
+```
+
+That will produce the following output:
+
+``` hs
+{-# LANGUAGE PackageImports #-}
+import qualified "semver" Data.SemVer
+main = print Data.SemVer.initial
+```
+
 ## Limitations
 
 Due to limitations in how GHC plugins work, Imp cannot be used to automatically

--- a/imp.cabal
+++ b/imp.cabal
@@ -46,6 +46,7 @@ library
   import: library
   autogen-modules: Paths_imp
   build-depends:
+    Cabal-syntax ^>=3.6.0.0 || ^>=3.8.1.0 || ^>=3.10.1.0,
     containers ^>=0.6.7,
     exceptions ^>=0.10.5,
     ghc ^>=9.4.1 || ^>=9.6.1 || ^>=9.8.1,
@@ -58,6 +59,7 @@ library
     Imp.Exception.InvalidModuleName
     Imp.Exception.InvalidOption
     Imp.Exception.InvalidPackage
+    Imp.Exception.InvalidPackageName
     Imp.Exception.ShowHelp
     Imp.Exception.ShowVersion
     Imp.Exception.UnexpectedArgument

--- a/imp.cabal
+++ b/imp.cabal
@@ -57,6 +57,7 @@ library
     Imp.Exception.InvalidAlias
     Imp.Exception.InvalidModuleName
     Imp.Exception.InvalidOption
+    Imp.Exception.InvalidPackage
     Imp.Exception.ShowHelp
     Imp.Exception.ShowVersion
     Imp.Exception.UnexpectedArgument
@@ -75,6 +76,8 @@ library
     Imp.Type.Config
     Imp.Type.Context
     Imp.Type.Flag
+    Imp.Type.Package
+    Imp.Type.PackageName
     Imp.Type.Source
     Imp.Type.Target
 

--- a/source/library/Imp.hs
+++ b/source/library/Imp.hs
@@ -13,7 +13,6 @@ import qualified Data.Set as Set
 import qualified GHC.Hs as Hs
 import qualified GHC.Plugins as Plugin
 import qualified GHC.Types.PkgQual as PkgQual
-import qualified GHC.Types.SourceText as SourceText
 import qualified Imp.Exception.ShowHelp as ShowHelp
 import qualified Imp.Exception.ShowVersion as ShowVersion
 import qualified Imp.Extra.Exception as Exception
@@ -153,12 +152,6 @@ createImport aliases packages target = do
             then Nothing
             else Just $ Hs.noLocA target,
         Hs.ideclPkgQual =
-          case Map.lookup (Target.fromModuleName target) packages of
-            Nothing -> PkgQual.NoRawPkgQual
-            Just packageName ->
-              PkgQual.RawPkgQual
-                . (\x -> SourceText.StringLiteral SourceText.NoSourceText (Plugin.mkFastString x) Nothing)
-                . Plugin.unpackFS
-                . (\(Plugin.PackageName x) -> x)
-                $ PackageName.toPackageName packageName
+          maybe PkgQual.NoRawPkgQual (PkgQual.RawPkgQual . PackageName.toStringLiteral) $
+            Map.lookup (Target.fromModuleName target) packages
       }

--- a/source/library/Imp.hs
+++ b/source/library/Imp.hs
@@ -12,6 +12,8 @@ import qualified Data.Maybe as Maybe
 import qualified Data.Set as Set
 import qualified GHC.Hs as Hs
 import qualified GHC.Plugins as Plugin
+import qualified GHC.Types.PkgQual as PkgQual
+import qualified GHC.Types.SourceText as SourceText
 import qualified Imp.Exception.ShowHelp as ShowHelp
 import qualified Imp.Exception.ShowVersion as ShowVersion
 import qualified Imp.Extra.Exception as Exception
@@ -25,6 +27,7 @@ import qualified Imp.Ghc as Ghc
 import qualified Imp.Type.Config as Config
 import qualified Imp.Type.Context as Context
 import qualified Imp.Type.Flag as Flag
+import qualified Imp.Type.PackageName as PackageName
 import qualified Imp.Type.Source as Source
 import qualified Imp.Type.Target as Target
 import qualified System.Exit as Exit
@@ -73,6 +76,7 @@ imp arguments this lHsModule = do
   config <- Config.fromFlags flags
   context <- Context.fromConfig config
   let aliases = Context.aliases context
+      packages = Context.packages context
       implicits =
         Set.map Target.toModuleName
           . Map.keysSet
@@ -86,7 +90,7 @@ imp arguments this lHsModule = do
         StateT.runState
           (Located.overValue (HsModule.overDecls $ overData $ updateQualifiedIdentifiers this implicits imports) lHsModule)
           Map.empty
-  pure $ fmap (HsModule.overImports $ updateImports this aliases moduleNames) newLHsModule
+  pure $ fmap (HsModule.overImports $ updateImports this aliases packages moduleNames) newLHsModule
 
 updateQualifiedIdentifiers ::
   (Data.Data a) =>
@@ -121,19 +125,21 @@ overData f = Data.gmapM $ overData f Monad.>=> f
 updateImports ::
   Plugin.ModuleName ->
   Map.Map Target.Target Source.Source ->
+  Map.Map Target.Target PackageName.PackageName ->
   Map.Map Plugin.ModuleName Hs.SrcSpanAnnN ->
   [Hs.LImportDecl Hs.GhcPs] ->
   [Hs.LImportDecl Hs.GhcPs]
-updateImports this aliases want imports =
+updateImports this aliases packages want imports =
   let have = Set.insert this . Set.fromList $ fmap (ImportDecl.toModuleName . Plugin.unLoc) imports
       need = Map.toList $ Map.withoutKeys want have
-   in imports <> Maybe.mapMaybe (\(m, l) -> Plugin.L (Hs.na2la l) <$> createImport aliases m) need
+   in imports <> Maybe.mapMaybe (\(m, l) -> Plugin.L (Hs.na2la l) <$> createImport aliases packages m) need
 
 createImport ::
   Map.Map Target.Target Source.Source ->
+  Map.Map Target.Target PackageName.PackageName ->
   Plugin.ModuleName ->
   Maybe (Hs.ImportDecl Hs.GhcPs)
-createImport aliases target = do
+createImport aliases packages target = do
   source <-
     case Map.lookup (Target.fromModuleName target) aliases of
       Nothing -> Just target
@@ -145,5 +151,14 @@ createImport aliases target = do
       { Hs.ideclAs =
           if source == target
             then Nothing
-            else Just $ Hs.noLocA target
+            else Just $ Hs.noLocA target,
+        Hs.ideclPkgQual =
+          case Map.lookup (Target.fromModuleName target) packages of
+            Nothing -> PkgQual.NoRawPkgQual
+            Just packageName ->
+              PkgQual.RawPkgQual
+                . (\x -> SourceText.StringLiteral SourceText.NoSourceText (Plugin.mkFastString x) Nothing)
+                . Plugin.unpackFS
+                . (\(Plugin.PackageName x) -> x)
+                $ PackageName.toPackageName packageName
       }

--- a/source/library/Imp/Exception/InvalidPackage.hs
+++ b/source/library/Imp/Exception/InvalidPackage.hs
@@ -1,0 +1,13 @@
+module Imp.Exception.InvalidPackage where
+
+import qualified Control.Monad.Catch as Exception
+
+newtype InvalidPackage
+  = InvalidPackage String
+  deriving (Eq, Show)
+
+instance Exception.Exception InvalidPackage where
+  displayException (InvalidPackage x) = "invalid package: " <> show x
+
+new :: String -> InvalidPackage
+new = InvalidPackage

--- a/source/library/Imp/Exception/InvalidPackageName.hs
+++ b/source/library/Imp/Exception/InvalidPackageName.hs
@@ -1,0 +1,13 @@
+module Imp.Exception.InvalidPackageName where
+
+import qualified Control.Monad.Catch as Exception
+
+newtype InvalidPackageName
+  = InvalidPackageName String
+  deriving (Eq, Show)
+
+instance Exception.Exception InvalidPackageName where
+  displayException (InvalidPackageName x) = "invalid package name: " <> show x
+
+new :: String -> InvalidPackageName
+new = InvalidPackageName

--- a/source/library/Imp/Type/Config.hs
+++ b/source/library/Imp/Type/Config.hs
@@ -4,10 +4,12 @@ import qualified Control.Monad as Monad
 import qualified Control.Monad.Catch as Exception
 import qualified Imp.Type.Alias as Alias
 import qualified Imp.Type.Flag as Flag
+import qualified Imp.Type.Package as Package
 
 data Config = Config
   { aliases :: [Alias.Alias],
     help :: Bool,
+    packages :: [Package.Package],
     version :: Bool
   }
   deriving (Eq, Show)
@@ -17,6 +19,7 @@ initial =
   Config
     { aliases = [],
       help = False,
+      packages = [],
       version = False
     }
 
@@ -29,4 +32,7 @@ applyFlag config flag = case flag of
     alias <- Alias.fromString string
     pure config {aliases = alias : aliases config}
   Flag.Help bool -> pure config {help = bool}
+  Flag.Package string -> do
+    package <- Package.fromString string
+    pure config {packages = package : packages config}
   Flag.Version bool -> pure config {version = bool}

--- a/source/library/Imp/Type/Context.hs
+++ b/source/library/Imp/Type/Context.hs
@@ -7,11 +7,14 @@ import qualified Imp.Exception.ShowHelp as ShowHelp
 import qualified Imp.Exception.ShowVersion as ShowVersion
 import qualified Imp.Type.Alias as Alias
 import qualified Imp.Type.Config as Config
+import qualified Imp.Type.Package as Package
+import qualified Imp.Type.PackageName as PackageName
 import qualified Imp.Type.Source as Source
 import qualified Imp.Type.Target as Target
 
-newtype Context = Context
-  { aliases :: Map.Map Target.Target Source.Source
+data Context = Context
+  { aliases :: Map.Map Target.Target Source.Source,
+    packages :: Map.Map Target.Target PackageName.PackageName
   }
   deriving (Eq, Show)
 
@@ -21,5 +24,6 @@ fromConfig config = do
   Monad.when (Config.version config) $ Exception.throwM ShowVersion.new
   pure
     Context
-      { aliases = Alias.toMap $ Config.aliases config
+      { aliases = Alias.toMap $ Config.aliases config,
+        packages = Package.toMap $ Config.packages config
       }

--- a/source/library/Imp/Type/Flag.hs
+++ b/source/library/Imp/Type/Flag.hs
@@ -46,7 +46,9 @@ options =
       []
       ["package"]
       (GetOpt.ReqArg Package "MODULE:PACKAGE")
-      "TODO"
+      "Specifies that MODULE should be imported from PACKAGE. \
+      \For example `--package=Data.Semver:semver` will import the `Data.SemVer` module from the `semver` package. \
+      \Later packages will overwrite earlier ones."
   ]
 
 fromArguments :: (Exception.MonadThrow m) => [String] -> m [Flag]

--- a/source/library/Imp/Type/Flag.hs
+++ b/source/library/Imp/Type/Flag.hs
@@ -48,6 +48,7 @@ options =
       (GetOpt.ReqArg Package "MODULE:PACKAGE")
       "Specifies that MODULE should be imported from PACKAGE. \
       \For example `--package=Data.Semver:semver` will import the `Data.SemVer` module from the `semver` package. \
+      \Note that using this option requires you to enable the `PackageImports` language extension. \
       \Later packages will overwrite earlier ones."
   ]
 

--- a/source/library/Imp/Type/Flag.hs
+++ b/source/library/Imp/Type/Flag.hs
@@ -9,6 +9,7 @@ import qualified System.Console.GetOpt as GetOpt
 data Flag
   = Alias String
   | Help Bool
+  | Package String
   | Version Bool
   deriving (Eq, Show)
 
@@ -40,7 +41,12 @@ options =
       (GetOpt.ReqArg Alias "SOURCE:TARGET")
       "Adds a new alias, allowing TARGET to be used in place of SOURCE. \
       \For example `--alias=Data.String:String` allows `String.words` to mean `Data.String.words`. \
-      \Later aliases will overwrite earlier ones."
+      \Later aliases will overwrite earlier ones.",
+    GetOpt.Option
+      []
+      ["package"]
+      (GetOpt.ReqArg Package "MODULE:PACKAGE")
+      "TODO"
   ]
 
 fromArguments :: (Exception.MonadThrow m) => [String] -> m [Flag]

--- a/source/library/Imp/Type/Package.hs
+++ b/source/library/Imp/Type/Package.hs
@@ -1,0 +1,25 @@
+module Imp.Type.Package where
+
+import qualified Control.Monad as Monad
+import qualified Control.Monad.Catch as Exception
+import qualified Data.Map as Map
+import qualified Imp.Exception.InvalidPackage as InvalidPackage
+import qualified Imp.Type.PackageName as PackageName
+import qualified Imp.Type.Target as Target
+
+data Package = Package
+  { module_ :: Target.Target,
+    package :: PackageName.PackageName
+  }
+  deriving (Eq, Show)
+
+fromString :: (Exception.MonadThrow m) => String -> m Package
+fromString string = do
+  let (before, after) = break (== ':') string
+  Monad.when (null after) . Exception.throwM $ InvalidPackage.new string
+  mdl <- Target.fromString before
+  pkg <- PackageName.fromString . drop 1 $ after
+  pure Package {module_ = mdl, package = pkg}
+
+toMap :: [Package] -> Map.Map Target.Target PackageName.PackageName
+toMap = Map.fromListWith (const id) . fmap (\x -> (module_ x, package x))

--- a/source/library/Imp/Type/PackageName.hs
+++ b/source/library/Imp/Type/PackageName.hs
@@ -1,20 +1,31 @@
 module Imp.Type.PackageName where
 
-import qualified GHC.Plugins as Plugin
+import qualified Control.Monad.Catch as Exception
+import qualified Distribution.Parsec as Parsec
+import qualified Distribution.Types.PackageName as PackageName
+import qualified GHC.Data.FastString as FastString
+import qualified GHC.Types.SourceText as SourceText
+import qualified Imp.Exception.InvalidPackageName as InvalidPackageName
 
--- TODO: Use Distribution.Types.PackageName from Cabal-syntax.
 newtype PackageName
-  = PackageName Plugin.PackageName
-  deriving (Eq)
+  = PackageName PackageName.PackageName
+  deriving (Eq, Show)
 
-instance Show PackageName where
-  show = const "TODO"
+fromCabal :: PackageName.PackageName -> PackageName
+fromCabal = PackageName
 
-fromPackageName :: Plugin.PackageName -> PackageName
-fromPackageName = PackageName
+toCabal :: PackageName -> PackageName.PackageName
+toCabal (PackageName x) = x
 
-toPackageName :: PackageName -> Plugin.PackageName
-toPackageName (PackageName x) = x
+fromString :: (Exception.MonadThrow m) => String -> m PackageName
+fromString x =
+  maybe (Exception.throwM $ InvalidPackageName.new x) (pure . fromCabal) $
+    Parsec.simpleParsec x
 
-fromString :: (Applicative m) => String -> m PackageName
-fromString = pure . fromPackageName . Plugin.PackageName . Plugin.mkFastString
+toStringLiteral :: PackageName -> SourceText.StringLiteral
+toStringLiteral x =
+  SourceText.StringLiteral
+    { SourceText.sl_st = SourceText.NoSourceText,
+      SourceText.sl_fs = FastString.mkFastString . PackageName.unPackageName $ toCabal x,
+      SourceText.sl_tc = Nothing
+    }

--- a/source/library/Imp/Type/PackageName.hs
+++ b/source/library/Imp/Type/PackageName.hs
@@ -1,0 +1,20 @@
+module Imp.Type.PackageName where
+
+import qualified GHC.Plugins as Plugin
+
+-- TODO: Use Distribution.Types.PackageName from Cabal-syntax.
+newtype PackageName
+  = PackageName Plugin.PackageName
+  deriving (Eq)
+
+instance Show PackageName where
+  show = const "TODO"
+
+fromPackageName :: Plugin.PackageName -> PackageName
+fromPackageName = PackageName
+
+toPackageName :: PackageName -> Plugin.PackageName
+toPackageName (PackageName x) = x
+
+fromString :: (Applicative m) => String -> m PackageName
+fromString = pure . fromPackageName . Plugin.PackageName . Plugin.mkFastString

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -98,6 +98,24 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "Imp" $ do
       "undefined = Example.undefined"
       "undefined = Example.undefined"
 
+  Hspec.it "" $ do
+    expectImp
+      ["--package=Data.SemVer:semver"]
+      "version = Data.SemVer.initial"
+      "import (implicit) qualified \"semver\" Data.SemVer\nversion = Data.SemVer.initial"
+
+  Hspec.it "" $ do
+    expectImp
+      ["--alias=Data.SemVer:V1", "--alias=Data.SemVer:V2", "--package=V1:semver", "--package=V2:semver-range"]
+      "one = V1.initial\ntwo = V2.anyVersion"
+      "import (implicit) qualified \"semver\" Data.SemVer as V1\nimport (implicit) qualified \"semver-range\" Data.SemVer as V2\none = V1.initial\ntwo = V2.anyVersion"
+
+  Hspec.it "" $ do
+    expectImp
+      ["--package=Data.SemVer:semver-range", "--package=Data.SemVer:semver"]
+      "version = Data.SemVer.initial"
+      "import (implicit) qualified \"semver\" Data.SemVer\nversion = Data.SemVer.initial"
+
 expectImp :: (Stack.HasCallStack) => [String] -> String -> String -> Hspec.Expectation
 expectImp arguments input expected = do
   before <- parseModule input

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -98,19 +98,19 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "Imp" $ do
       "undefined = Example.undefined"
       "undefined = Example.undefined"
 
-  Hspec.it "" $ do
+  Hspec.it "adds a package qualified import" $ do
     expectImp
       ["--package=Data.SemVer:semver"]
       "version = Data.SemVer.initial"
       "import (implicit) qualified \"semver\" Data.SemVer\nversion = Data.SemVer.initial"
 
-  Hspec.it "" $ do
+  Hspec.it "adds package qualified imports based on aliases" $ do
     expectImp
       ["--alias=Data.SemVer:V1", "--alias=Data.SemVer:V2", "--package=V1:semver", "--package=V2:semver-range"]
       "one = V1.initial\ntwo = V2.anyVersion"
       "import (implicit) qualified \"semver\" Data.SemVer as V1\nimport (implicit) qualified \"semver-range\" Data.SemVer as V2\none = V1.initial\ntwo = V2.anyVersion"
 
-  Hspec.it "" $ do
+  Hspec.it "later packages override earlier ones" $ do
     expectImp
       ["--package=Data.SemVer:semver-range", "--package=Data.SemVer:semver"]
       "version = Data.SemVer.initial"


### PR DESCRIPTION
Fixes #9. 

Still working on tidying this up. I was surprised to find that the `ghc` package does not have a parser for `PackageName`s in it. I think the best place to get that from is `Cabal-syntax`. 