### PR TITLE
Allow enabling groups of aliases

### DIFF
--- a/imp.cabal
+++ b/imp.cabal
@@ -63,7 +63,9 @@ library
     Imp.Exception.ShowHelp
     Imp.Exception.ShowVersion
     Imp.Exception.UnexpectedArgument
+    Imp.Exception.UnknownGroup
     Imp.Exception.UnknownOption
+    Imp.Extra.Either
     Imp.Extra.Exception
     Imp.Extra.HsModule
     Imp.Extra.HsParsedModule
@@ -78,6 +80,7 @@ library
     Imp.Type.Config
     Imp.Type.Context
     Imp.Type.Flag
+    Imp.Type.Group
     Imp.Type.Package
     Imp.Type.PackageName
     Imp.Type.Source

--- a/source/library/Imp/Exception/UnknownGroup.hs
+++ b/source/library/Imp/Exception/UnknownGroup.hs
@@ -1,0 +1,13 @@
+module Imp.Exception.UnknownGroup where
+
+import qualified Control.Monad.Catch as Exception
+
+newtype UnknownGroup
+  = UnknownGroup String
+  deriving (Eq, Show)
+
+instance Exception.Exception UnknownGroup where
+  displayException (UnknownGroup x) = "unknown group: " <> show x
+
+new :: String -> UnknownGroup
+new = UnknownGroup

--- a/source/library/Imp/Extra/Either.hs
+++ b/source/library/Imp/Extra/Either.hs
@@ -1,0 +1,6 @@
+module Imp.Extra.Either where
+
+import qualified Control.Exception as Exception
+
+throw :: (Exception.Exception e) => Either e a -> a
+throw = either Exception.throw id

--- a/source/library/Imp/Type/Config.hs
+++ b/source/library/Imp/Type/Config.hs
@@ -4,6 +4,7 @@ import qualified Control.Monad as Monad
 import qualified Control.Monad.Catch as Exception
 import qualified Imp.Type.Alias as Alias
 import qualified Imp.Type.Flag as Flag
+import qualified Imp.Type.Group as Group
 import qualified Imp.Type.Package as Package
 
 data Config = Config
@@ -31,6 +32,9 @@ applyFlag config flag = case flag of
   Flag.Alias string -> do
     alias <- Alias.fromString string
     pure config {aliases = alias : aliases config}
+  Flag.Group string -> do
+    group <- Group.fromString string
+    pure config {aliases = Group.toAliases group <> aliases config}
   Flag.Help bool -> pure config {help = bool}
   Flag.Package string -> do
     package <- Package.fromString string

--- a/source/library/Imp/Type/Flag.hs
+++ b/source/library/Imp/Type/Flag.hs
@@ -8,6 +8,7 @@ import qualified System.Console.GetOpt as GetOpt
 
 data Flag
   = Alias String
+  | Group String
   | Help Bool
   | Package String
   | Version Bool
@@ -42,6 +43,12 @@ options =
       "Adds a new alias, allowing TARGET to be used in place of SOURCE. \
       \For example `--alias=Data.String:String` allows `String.words` to mean `Data.String.words`. \
       \Later aliases will overwrite earlier ones.",
+    GetOpt.Option
+      []
+      ["group"]
+      (GetOpt.ReqArg Group "GROUP")
+      -- TODO: Improve description.
+      "Enables a named group of aliases.",
     GetOpt.Option
       []
       ["package"]

--- a/source/library/Imp/Type/Group.hs
+++ b/source/library/Imp/Type/Group.hs
@@ -1,0 +1,37 @@
+module Imp.Type.Group where
+
+import qualified Control.Monad.Catch as Exception
+import qualified Imp.Exception.UnknownGroup as UnknownGroup
+import qualified Imp.Extra.Either as Either
+import qualified Imp.Type.Alias as Alias
+import qualified Imp.Type.Source as Source
+import qualified Imp.Type.Target as Target
+
+data Group
+  = Base
+  -- TODO: Add more groups.
+  deriving (Eq, Show)
+
+fromString :: (Exception.MonadThrow m) => String -> m Group
+fromString x = case x of
+  "base" -> pure Base
+  _ -> Exception.throwM $ UnknownGroup.new x
+
+toAliases :: Group -> [Alias.Alias]
+toAliases x =
+  let alias s t =
+        Alias.Alias
+          { Alias.source = Either.throw $ Source.fromString s,
+            Alias.target = Either.throw $ Target.fromString t
+          }
+   in case x of
+        Base ->
+          [ alias "Control.Applicative" "Applicative",
+            alias "Control.Arrow" "Arrow",
+            alias "Control.Category" "Category",
+            alias "Control.Concurrent" "Concurrent",
+            alias "Control.Exception" "Exception",
+            alias "Control.Monad" "Monad",
+            alias "Control.Monad.IO.Class" "MonadIO"
+            -- TODO: Add more aliases.
+          ]

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -116,6 +116,12 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "Imp" $ do
       "version = Data.SemVer.initial"
       "import (implicit) qualified \"semver\" Data.SemVer\nversion = Data.SemVer.initial"
 
+  Hspec.it "supports groups of aliases" $ do
+    expectImp
+      ["--group=base"]
+      "main = Applicative.pure ()"
+      "import (implicit) qualified Control.Applicative as Applicative\nmain = Applicative.pure ()"
+
 expectImp :: (Stack.HasCallStack) => [String] -> String -> String -> Hspec.Expectation
 expectImp arguments input expected = do
   before <- parseModule input


### PR DESCRIPTION
Fixes #10. 

Now that I've implemented this, I'm not sure about it. I think there are two main problems:

- It's not clear which packages I should provide groups for. Everything that ships with GHC feels like a good start. What about common packages that aren't core libraries though? Do I just keep adding things forever? 
- Within a package, there's no obvious answer to how modules should be aliased. This is actually two sub-problems: which modules should be aliased at all, and what should their aliases be?

As a concrete example of the first problem, consider a library like `aeson`. It's the de facto standard library for dealing with JSON. Should it be included in a group? What about alternatives like `waargonaut` or `autodocodec`? I don't want to be the arbiter for which packages deserve a group, but I also don't want to provide groups for every package on Hackage. 

And for a concrete example of the second, consider the module `Control.Monad.Fail`. How should it be aliased: `Fail` or `MonadFail`? There's not a right answer. And this is a problem for every non-trivial alias. 